### PR TITLE
Point requirements.txt to Git repositories

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 unidecode
 requests
-kilt
-fairseq
+git+https://github.com/facebookresearch/KILT.git
+git+https://github.com/nicola-decao/fairseq.git@fixing_prefix_allowed_tokens_fn
 transformers


### PR DESCRIPTION
Hi GENRE team 👋 

Thank you for open-sourcing the code of the GENRE paper. This is incredible work!

I was attempting to install the requirements file and I got a failure on `kilt`, it looks like it disappeared from PyPI? I also saw the README note about `fairseq`. 

Thought you may want to point directly to the Git repos from the `requirements.txt`. If not desired, let me know and I'll close the PR.

Thanks!