### PR TITLE
Add integration test for document retrieval example

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,81 @@
+name: Test
+
+on:
+  push:
+    branches:
+      - main
+      - feature/*
+
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    name: Test
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      # Data
+      - name: Cache data
+        uses: actions/cache@v2
+        id: cache-data
+        with:
+          path: data/*
+          key: data-v1
+
+      - name: Download data
+        if: steps.cache-data.outputs.cache-hit != 'true'
+        run: |
+          sudo apt-get install axel -y
+          mkdir data
+          axel -n 20 http://dl.fbaipublicfiles.com/GENRE/kilt_titles_trie_dict.pkl -o data
+
+      # Models
+      - name: Cache models
+        uses: actions/cache@v2
+        id: cache-models
+        with:
+          path: models/*
+          key: models-v1
+
+      - name: Download models
+        if: steps.cache-models.outputs.cache-hit != 'true'
+        run: |
+          sudo apt-get install axel -y
+          mkdir models
+          axel -n 20 http://dl.fbaipublicfiles.com/GENRE/fairseq_wikipage_retrieval.tar.gz
+          tar -xvf fairseq_wikipage_retrieval.tar.gz --directory models
+
+      # Pip Dependencies
+      - name: Cache pip dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements-tests.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install pip dependencies
+        run: pip install -r requirements-test.txt
+
+      # Install Fairseq & Genre
+      - name: Install Fairseq
+        run: |
+          git clone -b fixing_prefix_allowed_tokens_fn --single-branch https://github.com/nicola-decao/fairseq.git
+          pip install -e ./fairseq
+
+      - name: Install GENRE
+        run: pip install -e .
+
+      # Run tests
+      - name: Pytest
+        run: pytest tests --verbose

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+# How to use:
+#   docker build --tag genre:latest .
+#   docker run --rm -it genre:latest /bin/bash
+#   docker run --rm -it -v $(pwd)/tests:/GENRE/genre/tests genre:latest /bin/bash
+#   pytest genre/tests
+FROM python:3.8
+
+WORKDIR /GENRE/
+
+RUN apt-get update && \
+    apt-get install axel -y
+
+RUN mkdir data && \
+    axel -n 20 http://dl.fbaipublicfiles.com/GENRE/kilt_titles_trie_dict.pkl -o data
+
+RUN mkdir models && \
+    axel -n 20 http://dl.fbaipublicfiles.com/GENRE/fairseq_wikipage_retrieval.tar.gz && \
+    tar -xvf fairseq_wikipage_retrieval.tar.gz --directory models && \
+    rm fairseq_wikipage_retrieval.tar.gz
+
+# Install PyTorch
+RUN pip install torch --no-cache-dir
+
+# Install dependencies
+RUN pip install pytest requests --no-cache-dir
+
+# Install fairseq
+RUN git clone -b fixing_prefix_allowed_tokens_fn --single-branch https://github.com/nicola-decao/fairseq.git
+RUN pip install -e ./fairseq
+
+# Install genre
+COPY . genre
+RUN pip install -e ./genre

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,3 @@
+torch
+requests
+pytest

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -1,0 +1,43 @@
+import pickle
+from unittest.mock import ANY
+
+import pytest
+
+from genre.trie import Trie
+from genre.fairseq_model import GENRE, GENREHubInterface
+
+
+@pytest.fixture(scope="session")
+def kilt_trie():
+    # load the prefix tree (trie)
+    with open("./data/kilt_titles_trie_dict.pkl", "rb") as f:
+        trie = Trie.load_from_dict(pickle.load(f))
+    return trie
+
+
+@pytest.fixture(scope="session")
+def fairseq_wikipage_retrieval():
+    model = GENRE.from_pretrained("./models/fairseq_wikipage_retrieval").eval()
+    return model
+
+
+EXPECTED_RESULTS_DOCUMENT_RETRIEVAL = [
+    [
+        {"text": "Albert Einstein", "score": ANY},
+        {"text": "Werner Bruschke", "score": ANY},
+        {"text": "Werner von Habsburg", "score": ANY},
+        {"text": "Werner von Moltke", "score": ANY},
+        {"text": "Werner von Eichstedt", "score": ANY},
+    ]
+]
+
+
+def test_example_document_retrieval(
+    kilt_trie: Trie, fairseq_wikipage_retrieval: GENREHubInterface
+):
+    sentences = ["Einstein was a German physicist."]
+    results = fairseq_wikipage_retrieval.sample(
+        sentences,
+        prefix_allowed_tokens_fn=lambda batch_id, sent: kilt_trie.get(sent.tolist()),
+    )
+    assert results == EXPECTED_RESULTS_DOCUMENT_RETRIEVAL


### PR DESCRIPTION
Hi GENRE team 👋 ,

This PR adds a Github Actions integration test corresponding to the document retrieval example. This could help provide a stronger guarantee that the example is functional.

The workflow uses caching to avoid re-downloading the trie data, the pre-trained model and the Python dependencies on every build. The builds should be triggered on every push events to feature branches or PRs to main.

Included as well: a Dockerfile which should help easily replicate a Linux environment with GENRE, Fairseq, a pre-trained model and the trie data.

Hope it helps!
